### PR TITLE
Import export_text from sklearn.tree

### DIFF
--- a/src/edu/uiowa/encoder/ScikitCART.py
+++ b/src/edu/uiowa/encoder/ScikitCART.py
@@ -8,14 +8,9 @@ can be found in the LICENSE file.
 
 from sklearn.metrics import accuracy_score 
 from sklearn import tree
-
-from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree import DecisionTreeClassifier, export_text
 import numpy as np
-
 from graphviz import Source
-
-#from scikit.tree import export_text
-from sklearn.tree.export import export_text
 
 from edu.uiowa.parser.Formula import PLTLFormula
 


### PR DESCRIPTION
sklearn.tree.export was removed from scikit-learn in version 0.24, which was released in December 2020